### PR TITLE
Release v1.0.0

### DIFF
--- a/detector/build.gradle
+++ b/detector/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.2'
-    id 'io.spring.dependency-management' version '1.1.6'
+    id 'maven-publish'
 }
 
 group = 'io.jeyong'
-version = '0.0.1-SNAPSHOT'
+version = '1.0.0'
 
 java {
     toolchain {
@@ -15,11 +15,12 @@ java {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter:3.3.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.3.2'
 }
 
 bootJar {
@@ -28,4 +29,15 @@ bootJar {
 
 jar {
     enabled = true
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            groupId = project.group
+            artifactId = 'jpa-nplus1-detector'
+            version = project.version
+        }
+    }
 }

--- a/detector/src/main/java/io/jeyong/detector/aop/NPlusOneDetectionAop.java
+++ b/detector/src/main/java/io/jeyong/detector/aop/NPlusOneDetectionAop.java
@@ -23,7 +23,7 @@ public final class NPlusOneDetectionAop {
         this.queryThreshold = queryThreshold;
     }
 
-    @Around("execution(* javax.sql.DataSource.getConnection())")
+    @Around("execution(* javax.sql.DataSource.getConnection())")  // TODO. ThreadLocal Optimization
     public Object wrapConnectionWithProxy(final ProceedingJoinPoint joinPoint) throws Throwable {
         final Connection originalConnection = (Connection) joinPoint.proceed();
         return ConnectionMethodInterceptor.createProxy(originalConnection, this::logNPlusOneIssues);

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,11 @@
+jdk:
+  - openjdk17
+
+before_install:
+  - sdk install java 17.0.2-zulu
+  - sdk use java 17.0.2-zulu
+  - sdk install maven
+  - mvn -v
+
+install:
+  - ./detector/gradlew build publishToMavenLocal


### PR DESCRIPTION
### ⭐ New Features
- **N+1 쿼리 감지 AOP 추가**
  - N+1 쿼리 문제를 자동으로 감지하고, 반복된 쿼리 횟수가 임계값을 초과할 경우 로그를 기록하는 기능을 추가했습니다.

- **요청별 쿼리 로깅 컨텍스트 추가**
  - 각 요청 내에서 발생하는 SQL 쿼리를 추적하고, N+1 문제를 감지할 수 있는 로깅 컨텍스트 기능을 추가했습니다.

- **Hibernate용 N+1 감지 Statement Inspector 추가**
  - Hibernate의 `StatementInspector`를 통해 `select` 쿼리의 반복 실행을 모니터링하고, N+1 문제를 감지할 수 있는 기능을 추가했습니다.

- **Spring Auto Configuration 적용**
  - 스프링 자동 구성을 통해 쉽게 활성화할 수 있도록 했습니다.  또한 별도의 수작업 없이도 설정 파일에서 간단히 기능을 켜고 끌 수 있도록 했습니다.

  ```yaml
  jpa:
    properties:
      hibernate:
        detector:
          enabled: true     # N+1 문제 감지 기능 활성화 여부 (기본 값: false)
          threshold: 2      # 쿼리 실행 횟수 기준 설정 (기본 값: 2, 예: 2회 이상 실행된 쿼리에 대해 N+1 문제 감지)

### 🔍 Test Enhancements
- **일대다(1:N) 관계에서 일(1) 조회시, 발생하는 N+1 문제에 대한 테스트 케이스 추가**
  - `/api/library/v1/authors` 엔드포인트: 클래스 단위의 @Transactional 상황에서, 감지기가 N+1 문제를 감지하는지 검증합니다.
  - `/api/library/v2/authors` 엔드포인트: 메서드 단위의 @Transactional 상황에서, 감지기가 N+1 문제를 감지하는지 검증합니다.
  - `/api/library/v3/authors` 엔드포인트: OSIV(Open Session In View) 패턴을 사용하는 상황에서, 감지기가 N+1 문제를 감지하는지 검증합니다.

### 🪲 Bug Fixes
- **N+1 쿼리 감지 방식 수정**
  - 초기에는 `@AfterReturning("@annotation(org.springframework.transaction.annotation.Transactional)")`을 사용하여 트랜잭션 종료 후 N+1 문제를 감지하려 했습니다. 하지만, 이 방식은 클래스 단위의 `@Transactional` 선언을 감지하지 못하며, OSIV(Open Session In View) 패턴을 사용하는 경우 지연 로딩을 감지할 수 없는 문제가 있었습니다. 
  - 다음으로, `@AfterReturning("java.sql.Connection.close()")`를 통해 트랜잭션 종료 후 N+1 문제를 감지하려 했으나, `Connection`은 스프링 컨테이너에서 관리하는 빈이 아니기 때문에 AOP 프록시 객체를 통한 적용이 불가능했습니다.
  - 현재는 `javax.sql.DataSource.getConnection()` 메서드를 AOP로 감싸서 데이터베이스 연결이 반환될 때 `ConnectionMethodInterceptor`를 통해 프록시 객체를 생성하고, `Connection`이 닫힐 때 로그를 기록하는 구조를 사용하고 있습니다. 
