### PR TITLE
Release v1.1.1

### DIFF
--- a/detector/build.gradle
+++ b/detector/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.3.2' apply false
+    id 'org.springframework.boot' version '3.0.0' apply false
     id 'maven-publish'
 }
 
@@ -19,8 +19,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter:3.3.2'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.3.2'
+    implementation 'org.springframework.boot:spring-boot-starter:3.0.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.0'
 }
 
 publishing {

--- a/detector/build.gradle
+++ b/detector/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.jeyong'
-version = '1.1.0'
+version = '1.1.1'
 
 java {
     toolchain {

--- a/detector/src/main/java/io/jeyong/detector/context/QueryLog.java
+++ b/detector/src/main/java/io/jeyong/detector/context/QueryLog.java
@@ -1,6 +1,5 @@
 package io.jeyong.detector.context;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -13,7 +12,6 @@ final class QueryLog {
     }
 
     public Map<String, Long> getNPlusOneQueries() {
-        // Using Collections.unmodifiableMap for Java 8 compatibility
-        return Collections.unmodifiableMap(queryOccurrences);
+        return Map.copyOf(queryOccurrences);
     }
 }

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.3.2'
-    id 'io.spring.dependency-management' version '1.1.6'
+    id 'org.springframework.boot' version '3.0.0'
+    id 'io.spring.dependency-management' version '1.1.0'
 }
 
 group = 'io.jeyong'


### PR DESCRIPTION
### 🔧 Refactoring

- **불변 맵 생성 방식 개선**
  - `QueryLog` 클래스에서 `Collections.unmodifiableMap` 대신 `Map.copyOf`를 사용하도록 변경하여, 원본 데이터 변경 시에도 불변성을 안전하게 유지할 수 있게 했습니다.
  
- **Spring Boot 버전 조정**
  - `detector` 프로젝트에서 `Spring Boot` 버전을 3.3.2에서 3.0.0으로 조정하여, 하위 버전과의 호환성을 개선했습니다.

- **하위 버전 호환성 검증**
  - `test` 프로젝트에서 `Spring Boot` 버전을 3.3.2에서 3.0.0으로, `io.spring.dependency-management` 버전을 1.1.6에서 1.1.0으로 조정하여 하위 버전의 호환성을 확인했습니다.

### 🛠️ Design Considerations
- **하위 버전 지원 검토**
  - 현재 Spring Boot 3.x와 Java 17을 지원하고 있으며, 향후 Spring Boot 2.x와 Java 8 지원 여부를 검토 중입니다. 

