### PR TITLE
Release v1.1.2

### DIFF
--- a/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorConfig.java
+++ b/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorConfig.java
@@ -27,7 +27,7 @@ public class NPlusOneDetectorConfig {
     }
 
     @Bean
-    public QueryLoggingContext loggingContext() {
+    public QueryLoggingContext queryLoggingContext() {
         return new QueryLoggingContext();
     }
 

--- a/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorConfig.java
+++ b/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorConfig.java
@@ -3,7 +3,10 @@ package io.jeyong.detector.config;
 import io.jeyong.detector.aop.NPlusOneDetectionAop;
 import io.jeyong.detector.context.QueryLoggingContext;
 import io.jeyong.detector.interceptor.NPlusOneStatementInspector;
+import jakarta.annotation.PostConstruct;
 import org.hibernate.cfg.AvailableSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -20,10 +23,17 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(NPlusOneDetectorProperties.class)
 public class NPlusOneDetectorConfig {
 
+    private static final Logger logger = LoggerFactory.getLogger(NPlusOneDetectorConfig.class);
+
     private final NPlusOneDetectorProperties nPlusOneDetectorProperties;
 
     public NPlusOneDetectorConfig(NPlusOneDetectorProperties nPlusOneDetectorProperties) {
         this.nPlusOneDetectorProperties = nPlusOneDetectorProperties;
+    }
+
+    @PostConstruct
+    public void logInitialization() {
+        logger.info("N+1 Detector is enabled with threshold: {}", nPlusOneDetectorProperties.getThreshold());
     }
 
     @Bean

--- a/test/src/main/java/io/jeyong/test/InitData.java
+++ b/test/src/main/java/io/jeyong/test/InitData.java
@@ -4,6 +4,11 @@ import io.jeyong.test.case1.entity.Author;
 import io.jeyong.test.case1.entity.Book;
 import io.jeyong.test.case1.repository.AuthorRepository;
 import io.jeyong.test.case1.repository.BookRepository;
+import io.jeyong.test.case2.entity.Order;
+import io.jeyong.test.case2.entity.Product;
+import io.jeyong.test.case2.repository.OrderRepository;
+import io.jeyong.test.case2.repository.ProductRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -18,11 +23,14 @@ public class InitData {
 
     private final AuthorRepository authorRepository;
     private final BookRepository bookRepository;
+    private final OrderRepository orderRepository;
+    private final ProductRepository productRepository;
 
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
     public void initData() {
         initCase1();
+        initCase2();
     }
 
     private void initCase1() {
@@ -51,4 +59,42 @@ public class InitData {
         bookRepository.save(book2);
         bookRepository.save(book3);
     }
+
+    private void initCase2() {
+        Order order1 = new Order();
+        order1.setOrderNumber("Order 1");
+
+        Order order2 = new Order();
+        order2.setOrderNumber("Order 2");
+
+        Order order3 = new Order();
+        order3.setOrderNumber("Order 3");
+
+        orderRepository.save(order1);
+        orderRepository.save(order2);
+        orderRepository.save(order3);
+
+        Product product1 = new Product();
+        product1.setName("Product 1");
+        product1.setPrice(100.0);
+        product1.setOrder(order1);
+
+        Product product2 = new Product();
+        product2.setName("Product 2");
+        product2.setPrice(200.0);
+        product2.setOrder(order1);
+
+        Product product3 = new Product();
+        product3.setName("Product 3");
+        product3.setPrice(300.0);
+        product3.setOrder(order2);
+
+        Product product4 = new Product();
+        product4.setName("Product 4");
+        product4.setPrice(150.0);
+        product4.setOrder(order3);
+
+        productRepository.saveAll(List.of(product1, product2, product3, product4));
+    }
+
 }

--- a/test/src/main/java/io/jeyong/test/case2/controller/ProductController.http
+++ b/test/src/main/java/io/jeyong/test/case2/controller/ProductController.http
@@ -1,0 +1,2 @@
+### Product와 Order는 다대일(N:1) 관계이며, 모든 Product를 조회한 후 각 Product에 대해 별도의 쿼리로 Order를 조회
+GET http://localhost:8080/api/products

--- a/test/src/main/java/io/jeyong/test/case2/controller/ProductController.java
+++ b/test/src/main/java/io/jeyong/test/case2/controller/ProductController.java
@@ -1,0 +1,25 @@
+package io.jeyong.test.case2.controller;
+
+import io.jeyong.test.case2.entity.Product;
+import io.jeyong.test.case2.service.ProductService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    /**
+     * Product와 Order는 다대일(N:1) 관계이며, 모든 Product를 조회한 후 각 Product에 대해 별도의 쿼리로 Order를 조회
+     */
+    @GetMapping
+    public List<Product> getAllProducts() {
+        return productService.findAllProducts();
+    }
+}

--- a/test/src/main/java/io/jeyong/test/case2/controller/ProductController.java
+++ b/test/src/main/java/io/jeyong/test/case2/controller/ProductController.java
@@ -16,7 +16,10 @@ public class ProductController {
     private final ProductService productService;
 
     /**
-     * Product와 Order는 다대일(N:1) 관계이며, 모든 Product를 조회한 후 각 Product에 대해 별도의 쿼리로 Order를 조회
+     * @formatter:off
+     * Product와 Order는 다대일(N:1) 관계이며,
+     * 모든 Product를 조회한 후 각 Product에 대해 별도의 쿼리로 Order를 조회
+     * @formatter:on
      */
     @GetMapping
     public List<Product> getAllProducts() {

--- a/test/src/main/java/io/jeyong/test/case2/entity/Order.java
+++ b/test/src/main/java/io/jeyong/test/case2/entity/Order.java
@@ -1,0 +1,24 @@
+package io.jeyong.test.case2.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "`order`")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String orderNumber;
+}

--- a/test/src/main/java/io/jeyong/test/case2/entity/Product.java
+++ b/test/src/main/java/io/jeyong/test/case2/entity/Product.java
@@ -1,0 +1,33 @@
+package io.jeyong.test.case2.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private Double price;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    @JsonIgnore
+    private Order order;
+}

--- a/test/src/main/java/io/jeyong/test/case2/repository/OrderRepository.java
+++ b/test/src/main/java/io/jeyong/test/case2/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package io.jeyong.test.case2.repository;
+
+import io.jeyong.test.case2.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/test/src/main/java/io/jeyong/test/case2/repository/ProductRepository.java
+++ b/test/src/main/java/io/jeyong/test/case2/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package io.jeyong.test.case2.repository;
+
+import io.jeyong.test.case2.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/test/src/main/java/io/jeyong/test/case2/service/ProductService.java
+++ b/test/src/main/java/io/jeyong/test/case2/service/ProductService.java
@@ -1,0 +1,22 @@
+package io.jeyong.test.case2.service;
+
+import io.jeyong.test.case2.entity.Product;
+import io.jeyong.test.case2.repository.ProductRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public List<Product> findAllProducts() {
+        List<Product> products = productRepository.findAll();
+        products.forEach(product -> product.getOrder().getOrderNumber());  // N+1 문제 발생 가능
+        return products;
+    }
+}

--- a/test/src/main/java/io/jeyong/test/case2/service/ProductService.java
+++ b/test/src/main/java/io/jeyong/test/case2/service/ProductService.java
@@ -16,7 +16,7 @@ public class ProductService {
     @Transactional
     public List<Product> findAllProducts() {
         List<Product> products = productRepository.findAll();
-        products.forEach(product -> product.getOrder().getOrderNumber());  // N+1 문제 발생 가능
+        products.forEach(product -> product.getOrder().getOrderNumber());  // N+1 문제 발생
         return products;
     }
 }

--- a/test/src/test/java/io/jeyong/test/case2/controller/ProductControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/case2/controller/ProductControllerTest.java
@@ -1,0 +1,42 @@
+package io.jeyong.test.case2.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class ProductControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    /**
+     * @formatter:off
+     * Product and Order have a many-to-one (N:1) relationship.
+     * This test verifies if an N+1 issue occurs when accessing the /api/products endpoint,
+     * which fetches all Products and triggers separate queries to fetch the associated Order for each Product.
+     * @formatter:on
+     */
+    @Test
+    void testGetProducts(CapturedOutput output) {
+        String url = "http://localhost:" + port + "/api/products";
+        ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(output).contains("N+1 issue detected");
+    }
+}

--- a/test/src/test/java/io/jeyong/test/case2/service/ProductServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/case2/service/ProductServiceTest.java
@@ -1,0 +1,32 @@
+package io.jeyong.test.case2.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest
+public class ProductServiceTest {
+
+    @Autowired
+    private ProductService productService;
+
+    /**
+     * @formatter:off
+     * Product and Order have a many-to-one (N:1) relationship.
+     * This test verifies if an N+1 issue occurs when fetching all Products,
+     * which then trigger separate queries to fetch the associated Order for each Product.
+     * @formatter:on
+     */
+    @Test
+    void testNPlusOneDetection(CapturedOutput output) {
+        productService.findAllProducts();
+
+        assertThat(output).contains("N+1 issue detected");
+    }
+}


### PR DESCRIPTION
### ⭐ New Features

- **초기화 로그 활성화**
  - N+1 Detector가 활성화되었을 때, 초기화 시점에 관련 로그가 출력되도록 기능을 추가했습니다.
  ```plaintext
  2024-08-27T14:59:54.307+09:00 INFO 9448 --- i.j.d.config.NPlusOneDetectorConfig : N+1 Detector is enabled with threshold: 2
  ```

### 🔍 Test Enhancements

- **다대일(N:1) 관계에서 다(N)를 조회시, 발생하는 N+1 문제에 대한 테스트 케이스 추가**
  - `/api/products` 엔드포인트: `Product`와 `Order` 간의 다대일(N:1) 관계에서 모든 `Product`를 조회한 후, 각 `Product`에 대해 별도의 쿼리로 `Order`를 조회할 때, 감지기가 N+1 문제를 감지하는지 검증합니다.

### 🪲 Bug Fixes

- **빈 이름 충돌 오류 해결**
  - 기존의 `LoggingContext` 빈 이름을 `QueryLoggingContext`로 변경하여, 빈 이름이 동일해서 발생하는 오류를 해결했습니다.
