### PR TITLE
Release v1.2.0

### DIFF
--- a/detector/build.gradle
+++ b/detector/build.gradle
@@ -20,7 +20,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter:3.0.0'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.0'
+    implementation 'org.hibernate.orm:hibernate-core:6.0.0.Final'
+    implementation 'org.springframework.boot:spring-boot-starter-aop:3.0.0'
 }
 
 publishing {

--- a/detector/build.gradle
+++ b/detector/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.jeyong'
-version = '1.1.1'
+version = '1.2.0'
 
 java {
     toolchain {

--- a/detector/src/main/java/io/jeyong/detector/interceptor/NPlusOneStatementInspector.java
+++ b/detector/src/main/java/io/jeyong/detector/interceptor/NPlusOneStatementInspector.java
@@ -6,6 +6,7 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
 public final class NPlusOneStatementInspector implements StatementInspector {
 
     private static final String SELECT_KEYWORD = "select";
+    private static final String IN_CLAUSE_KEYWORD = " in(";
     private final QueryLoggingContext queryLoggingContext;
 
     public NPlusOneStatementInspector(final QueryLoggingContext queryLoggingContext) {
@@ -14,7 +15,7 @@ public final class NPlusOneStatementInspector implements StatementInspector {
 
     @Override
     public String inspect(final String sql) {
-        if (isSelectQuery(sql)) {
+        if (isSelectQuery(sql) && !isBatchSizeQuery(sql)) {
             queryLoggingContext.logQueryOccurrence(sql);
         }
         return sql;
@@ -22,5 +23,9 @@ public final class NPlusOneStatementInspector implements StatementInspector {
 
     private boolean isSelectQuery(final String sql) {
         return sql.trim().toLowerCase().startsWith(SELECT_KEYWORD);
+    }
+
+    private boolean isBatchSizeQuery(final String sql) {
+        return sql.toLowerCase().contains(IN_CLAUSE_KEYWORD);
     }
 }

--- a/test/src/main/java/io/jeyong/test/InitData.java
+++ b/test/src/main/java/io/jeyong/test/InitData.java
@@ -8,6 +8,10 @@ import io.jeyong.test.case2.entity.Order;
 import io.jeyong.test.case2.entity.Product;
 import io.jeyong.test.case2.repository.OrderRepository;
 import io.jeyong.test.case2.repository.ProductRepository;
+import io.jeyong.test.case3.entity.Member;
+import io.jeyong.test.case3.entity.Team;
+import io.jeyong.test.case3.repository.MemberRepository;
+import io.jeyong.test.case3.repository.TeamRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,12 +29,15 @@ public class InitData {
     private final BookRepository bookRepository;
     private final OrderRepository orderRepository;
     private final ProductRepository productRepository;
+    private final TeamRepository teamRepository;
+    private final MemberRepository memberRepository;
 
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
     public void initData() {
         initCase1();
         initCase2();
+        initCase3();
     }
 
     private void initCase1() {
@@ -97,4 +104,36 @@ public class InitData {
         productRepository.saveAll(List.of(product1, product2, product3, product4));
     }
 
+    private void initCase3() {
+        Team team1 = new Team();
+        team1.setName("Team 1");
+
+        Team team2 = new Team();
+        team2.setName("Team 2");
+
+        Team team3 = new Team();
+        team3.setName("Team 3");
+
+        teamRepository.save(team1);
+        teamRepository.save(team2);
+        teamRepository.save(team3);
+
+        Member member1 = new Member();
+        member1.setName("Member 1");
+        member1.setTeam(team1);
+
+        Member member2 = new Member();
+        member2.setName("Member 2");
+        member2.setTeam(team1);
+
+        Member member3 = new Member();
+        member3.setName("Member 3");
+        member3.setTeam(team2);
+
+        Member member4 = new Member();
+        member4.setName("Member 4");
+        member4.setTeam(team3);
+
+        memberRepository.saveAll(List.of(member1, member2, member3, member4));
+    }
 }

--- a/test/src/main/java/io/jeyong/test/case1/controller/LibraryController.http
+++ b/test/src/main/java/io/jeyong/test/case1/controller/LibraryController.http
@@ -1,8 +1,8 @@
-### 클래스 단위의 @Transactional 선언
+### 클래스 단위의 @Transactional 상황에서 감지하는 것을 검증
 GET http://localhost:8080/api/library/v1/authors
 
-### 메서드 단위의 @Transactional 선언
+### 메서드 단위의 @Transactional 상황에서 감지하는 것을 검증
 GET http://localhost:8080/api/library/v2/authors
 
-### OSIV를 이용한 지연 조회
+### OSIV를 이용한 지연 조회 상황에서 감지하는 것을 검증
 GET http://localhost:8080/api/library/v3/authors

--- a/test/src/main/java/io/jeyong/test/case1/controller/LibraryController.java
+++ b/test/src/main/java/io/jeyong/test/case1/controller/LibraryController.java
@@ -28,8 +28,7 @@ public class LibraryController {
      */
     @GetMapping("/v1/authors")
     public List<Author> getAuthorsV1() {
-        List<Author> allAuthors = libraryServiceV1.findAllAuthors();
-        return allAuthors;
+        return libraryServiceV1.findAllAuthors();
     }
 
     /**
@@ -41,8 +40,7 @@ public class LibraryController {
      */
     @GetMapping("/v2/authors")
     public List<Author> getAuthorsV2() {
-        List<Author> allAuthors = libraryServiceV2.findAllAuthors();
-        return allAuthors;
+        return libraryServiceV2.findAllAuthors();
     }
 
     /**

--- a/test/src/main/java/io/jeyong/test/case1/controller/LibraryController.java
+++ b/test/src/main/java/io/jeyong/test/case1/controller/LibraryController.java
@@ -19,9 +19,12 @@ public class LibraryController {
     private final LibraryServiceV2 libraryServiceV2;
     private final LibraryServiceV3 libraryServiceV3;
 
-
     /**
-     * 클래스 단위의 @Transactional 선언
+     * @formatter:off
+     * Author과 Book는 일대다(1:N) 관계이며,
+     * 모든 Author을 조회한 후 각 Author에 대해 별도의 쿼리로 Book을 조회
+     * 클래스 단위의 @Transactional 상황에서 감지하는 것을 검증
+     * @formatter:on
      */
     @GetMapping("/v1/authors")
     public List<Author> getAuthorsV1() {
@@ -30,7 +33,11 @@ public class LibraryController {
     }
 
     /**
-     * 메서드 단위의 @Transactional 선언
+     * @formatter:off
+     * Author과 Book는 일대다(1:N) 관계이며,
+     * 모든 Author을 조회한 후 각 Author에 대해 별도의 쿼리로 Book을 조회
+     * 메서드 단위의 @Transactional 상황에서 감지하는 것을 검증
+     * @formatter:on
      */
     @GetMapping("/v2/authors")
     public List<Author> getAuthorsV2() {
@@ -39,7 +46,11 @@ public class LibraryController {
     }
 
     /**
-     * OSIV를 이용한 지연 조회
+     * @formatter:off
+     * Author과 Book는 일대다(1:N) 관계이며,
+     * 모든 Author을 조회한 후 각 Author에 대해 별도의 쿼리로 Book을 조회
+     * OSIV를 이용한 지연 조회 상황에서 감지하는 것을 검증
+     * @formatter:on
      */
     @GetMapping("/v3/authors")
     public List<Author> getAuthorsV3() {

--- a/test/src/main/java/io/jeyong/test/case1/service/LibraryServiceV3.java
+++ b/test/src/main/java/io/jeyong/test/case1/service/LibraryServiceV3.java
@@ -15,7 +15,6 @@ public class LibraryServiceV3 {
 
     @Transactional
     public List<Author> findAllAuthors() {
-        List<Author> authors = authorRepository.findAll();
-        return authors;
+        return authorRepository.findAll();
     }
 }

--- a/test/src/main/java/io/jeyong/test/case2/controller/ProductController.http
+++ b/test/src/main/java/io/jeyong/test/case2/controller/ProductController.http
@@ -1,2 +1,2 @@
-### Product와 Order는 다대일(N:1) 관계이며, 모든 Product를 조회한 후 각 Product에 대해 별도의 쿼리로 Order를 조회
+### 다(N)를 조회하는 상황에서 감지하는 것을 검증
 GET http://localhost:8080/api/products

--- a/test/src/main/java/io/jeyong/test/case2/controller/ProductController.java
+++ b/test/src/main/java/io/jeyong/test/case2/controller/ProductController.java
@@ -19,6 +19,7 @@ public class ProductController {
      * @formatter:off
      * Product와 Order는 다대일(N:1) 관계이며,
      * 모든 Product를 조회한 후 각 Product에 대해 별도의 쿼리로 Order를 조회
+     * 다(N)를 조회하는 상황에서 감지하는 것을 검증
      * @formatter:on
      */
     @GetMapping

--- a/test/src/main/java/io/jeyong/test/case3/controller/TeamController.http
+++ b/test/src/main/java/io/jeyong/test/case3/controller/TeamController.http
@@ -1,2 +1,2 @@
-### @BatchSize 상황에서 N+1 감지기가 이를 감지하지 않는 것을 검증
+### @BatchSize 상황에서 감지하지 않는 것을 검증
 GET http://localhost:8080/api/teams

--- a/test/src/main/java/io/jeyong/test/case3/controller/TeamController.http
+++ b/test/src/main/java/io/jeyong/test/case3/controller/TeamController.http
@@ -1,0 +1,2 @@
+### @BatchSize 상황에서 N+1 감지기가 이를 감지하지 않는 것을 검증
+GET http://localhost:8080/api/teams

--- a/test/src/main/java/io/jeyong/test/case3/controller/TeamController.java
+++ b/test/src/main/java/io/jeyong/test/case3/controller/TeamController.java
@@ -19,7 +19,7 @@ public class TeamController {
      * @formatter:off
      * Team과 Member는 일대다(1:N) 관계이며,
      * 모든 Team을 조회한 후 각 Team에 대해 별도의 쿼리로 Member를 조회
-     * @BatchSize 상황에서 N+1 감지기가 이를 감지하지 않는 것을 검증
+     * @BatchSize 상황에서 감지하지 않는 것을 검증
      * @formatter:on
      */
     @GetMapping

--- a/test/src/main/java/io/jeyong/test/case3/controller/TeamController.java
+++ b/test/src/main/java/io/jeyong/test/case3/controller/TeamController.java
@@ -1,0 +1,29 @@
+package io.jeyong.test.case3.controller;
+
+import io.jeyong.test.case3.entity.Team;
+import io.jeyong.test.case3.service.TeamService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/teams")
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamService teamService;
+
+    /**
+     * @formatter:off
+     * Team과 Member는 일대다(1:N) 관계이며,
+     * 모든 Team을 조회한 후 각 Team에 대해 별도의 쿼리로 Member를 조회
+     * @BatchSize 상황에서 N+1 감지기가 이를 감지하지 않는 것을 검증
+     * @formatter:on
+     */
+    @GetMapping
+    public List<Team> getAllTeams() {
+        return teamService.findAllTeams();
+    }
+}

--- a/test/src/main/java/io/jeyong/test/case3/entity/Member.java
+++ b/test/src/main/java/io/jeyong/test/case3/entity/Member.java
@@ -1,0 +1,31 @@
+package io.jeyong.test.case3.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+}

--- a/test/src/main/java/io/jeyong/test/case3/entity/Team.java
+++ b/test/src/main/java/io/jeyong/test/case3/entity/Team.java
@@ -1,0 +1,31 @@
+package io.jeyong.test.case3.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "team")
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "team")
+    @BatchSize(size = 2)  // BatchSize 설정
+    private List<Member> members;
+}

--- a/test/src/main/java/io/jeyong/test/case3/repository/MemberRepository.java
+++ b/test/src/main/java/io/jeyong/test/case3/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package io.jeyong.test.case3.repository;
+
+import io.jeyong.test.case3.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/test/src/main/java/io/jeyong/test/case3/repository/TeamRepository.java
+++ b/test/src/main/java/io/jeyong/test/case3/repository/TeamRepository.java
@@ -1,0 +1,7 @@
+package io.jeyong.test.case3.repository;
+
+import io.jeyong.test.case3.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+}

--- a/test/src/main/java/io/jeyong/test/case3/service/TeamService.java
+++ b/test/src/main/java/io/jeyong/test/case3/service/TeamService.java
@@ -1,0 +1,22 @@
+package io.jeyong.test.case3.service;
+
+import io.jeyong.test.case3.entity.Team;
+import io.jeyong.test.case3.repository.TeamRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+
+    @Transactional
+    public List<Team> findAllTeams() {
+        List<Team> teams = teamRepository.findAll();
+        teams.forEach(team -> team.getMembers().size());  // N+1 문제 발생 가능
+        return teams;
+    }
+}

--- a/test/src/test/java/io/jeyong/test/case1/controller/LibraryControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/case1/controller/LibraryControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,13 +25,8 @@ class LibraryControllerTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
-    /**
-     * @formatter:off
-     * V1 Controller: Test if N+1 issue occurs
-     * The N+1 issue should be detected at the /api/library/v1/authors endpoint.
-     * @formatter:on
-     */
     @Test
+    @DisplayName("클래스 단위의 @Transactional 상황에서 감지하는 것을 검증")
     void testGetAuthorsV1(CapturedOutput output) {
         String url = "http://localhost:" + port + "/api/library/v1/authors";
         ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
@@ -39,13 +35,8 @@ class LibraryControllerTest {
         assertThat(output).contains("N+1 issue detected");
     }
 
-    /**
-     * @formatter:off
-     * V2 Controller: Test if N+1 issue occurs
-     * The N+1 issue should be detected at the /api/library/v2/authors endpoint.
-     * @formatter:on
-     */
     @Test
+    @DisplayName("메서드 단위의 @Transactional 상황에서 감지하는 것을 검증")
     void testGetAuthorsV2(CapturedOutput output) {
         String url = "http://localhost:" + port + "/api/library/v2/authors";
         ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
@@ -54,13 +45,8 @@ class LibraryControllerTest {
         assertThat(output).contains("N+1 issue detected");
     }
 
-    /**
-     * @formatter:off
-     * V3 Controller: Test if N+1 issue occurs
-     * The N+1 issue should be detected at the /api/library/v3/authors endpoint using OSIV.
-     * @formatter:on
-     */
     @Test
+    @DisplayName("OSIV를 이용한 지연 조회 상황에서 감지하는 것을 검증")
     void testGetAuthorsV3(CapturedOutput output) {
         String url = "http://localhost:" + port + "/api/library/v3/authors";
         ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);

--- a/test/src/test/java/io/jeyong/test/case1/service/LibraryServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/case1/service/LibraryServiceTest.java
@@ -2,6 +2,7 @@ package io.jeyong.test.case1.service;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,40 +23,25 @@ public class LibraryServiceTest {
     @Autowired
     private LibraryServiceV3 libraryServiceV3;
 
-    /**
-     * @formatter:off
-     * V1 Service: Verify if N+1 issue occurs when using class-level @Transactional.
-     * The N+1 issue should occur in LibraryServiceV1.
-     * @formatter:on
-     */
     @Test
-    void testNPlusOneDetectionInV1(CapturedOutput output) {
+    @DisplayName("클래스 단위의 @Transactional 상황에서 감지하는 것을 검증")
+    void testFindAllAuthorsV1(CapturedOutput output) {
         libraryServiceV1.findAllAuthors();
 
         assertThat(output).contains("N+1 issue detected");
     }
 
-    /**
-     * @formatter:off
-     * V2 Service: Verify if N+1 issue occurs when using method-level @Transactional.
-     * The N+1 issue should occur in LibraryServiceV2.
-     * @formatter:on
-     */
     @Test
-    void testNPlusOneDetectionInV2(CapturedOutput output) {
+    @DisplayName("메서드 단위의 @Transactional 상황에서 감지하는 것을 검증")
+    void testFindAllAuthorsV2(CapturedOutput output) {
         libraryServiceV2.findAllAuthors();
 
         assertThat(output).contains("N+1 issue detected");
     }
 
-    /**
-     * @formatter:off
-     * V3 Service: Verify if N+1 issue does not occur when using OSIV.
-     * The N+1 issue should not occur in LibraryServiceV3.
-     * @formatter:on
-     */
     @Test
-    void testNPlusOneDetectionInV3(CapturedOutput output) {
+    @DisplayName("OSIV를 이용한 지연 조회 상황에서 감지하는 것을 검증")
+    void testFindAllAuthorsV3(CapturedOutput output) {
         libraryServiceV3.findAllAuthors();
 
         assertThat(output).doesNotContain("N+1 issue detected");

--- a/test/src/test/java/io/jeyong/test/case2/controller/ProductControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/case2/controller/ProductControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,14 +25,8 @@ class ProductControllerTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
-    /**
-     * @formatter:off
-     * Product and Order have a many-to-one (N:1) relationship.
-     * This test verifies if an N+1 issue occurs when accessing the /api/products endpoint,
-     * which fetches all Products and triggers separate queries to fetch the associated Order for each Product.
-     * @formatter:on
-     */
     @Test
+    @DisplayName("다(N)를 조회하는 상황에서 감지하는 것을 검증")
     void testGetProducts(CapturedOutput output) {
         String url = "http://localhost:" + port + "/api/products";
         ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);

--- a/test/src/test/java/io/jeyong/test/case2/service/ProductServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/case2/service/ProductServiceTest.java
@@ -2,6 +2,7 @@ package io.jeyong.test.case2.service;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,15 +17,9 @@ public class ProductServiceTest {
     @Autowired
     private ProductService productService;
 
-    /**
-     * @formatter:off
-     * Product and Order have a many-to-one (N:1) relationship.
-     * This test verifies if an N+1 issue occurs when fetching all Products,
-     * which then trigger separate queries to fetch the associated Order for each Product.
-     * @formatter:on
-     */
     @Test
-    void testNPlusOneDetection(CapturedOutput output) {
+    @DisplayName("다(N)를 조회하는 상황에서 감지하는 것을 검증")
+    void testFindAllProducts(CapturedOutput output) {
         productService.findAllProducts();
 
         assertThat(output).contains("N+1 issue detected");

--- a/test/src/test/java/io/jeyong/test/case3/controller/TeamControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/case3/controller/TeamControllerTest.java
@@ -1,0 +1,37 @@
+package io.jeyong.test.case3.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class TeamControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("@BatchSize 상황에서 감지하지 않는 것을 검증")
+    void testGetAllTeams(CapturedOutput output) {
+        String url = "http://localhost:" + port + "/api/teams";
+        ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(output).doesNotContain("N+1 issue detected");
+    }
+}

--- a/test/src/test/java/io/jeyong/test/case3/service/TeamServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/case3/service/TeamServiceTest.java
@@ -1,0 +1,27 @@
+package io.jeyong.test.case3.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest
+public class TeamServiceTest {
+
+    @Autowired
+    private TeamService teamService;
+
+    @Test
+    @DisplayName("@BatchSize 상황에서 감지하지 않는 것을 검증")
+    void testFindAllTeams(CapturedOutput output) {
+        teamService.findAllTeams();
+
+        assertThat(output).doesNotContain("N+1 issue detected");
+    }
+}


### PR DESCRIPTION
### 🔧 Refactoring
- **라이브러리 의존성 최소화**
  - 기존에 사용하던 `spring-boot-starter-data-jpa` 의존성을 제거하고, 필요한 최소한의 라이브러리(`spring-boot-starter`, `hibernate-core`, `spring-boot-starter-aop`)만 사용하도록 변경했습니다.

### 🔍 Test Enhancements
- **일대다(1:N) 관계에서 일(1) 조회시 BatchSize를 사용하는 상황에 대한 테스트 케이스 추가**
  - `Team`과 `Member` 간의 일대다(1:N) 관계에서, 모든 `Team`을 조회한 후 각 `Team`의 `Member`를 별도의 쿼리로 조회할 때, `@BatchSize`가 적용된 상황에서 감지기가 N+1 문제로 잘못 감지하지 않는지 검증합니다.

- **테스트의 목적 명시**
  - 테스트의 목적을 명확히 하기 위해, 모든 테스트 메서드에 `@DisplayName`을 추가하여 테스트가 어떤 상황을 검증하는지 명시했습니다.

### 🪲 Bug Fixes
- **BatchSize 상황에서의 N+1 감지 문제 수정**
  - 기존의 N+1 감지 기능은 `@BatchSize`가 적용된 쿼리도 N+1 문제로 잘못 감지하는 문제가 있었습니다. 이를 수정하여, `@BatchSize`가 적용된 경우에는 N+1 문제로 감지되지 않도록 했습니다.
