### PR TITLE
Release v1.3.2

### DIFF
--- a/detector/build.gradle
+++ b/detector/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.jeyong'
-version = '1.3.1'
+version = '1.3.2'
 
 java {
     toolchain {

--- a/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorProperties.java
+++ b/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorProperties.java
@@ -2,6 +2,48 @@ package io.jeyong.detector.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+// @formatter:off
+/**
+ * <p>
+ * Configuration properties for the N+1 Query Detector in JPA (Hibernate).
+ * </p>
+ *
+ * <p>
+ * To enable the N+1 query detector and customize its behavior, users
+ * can configure the following properties in the application configuration
+ * (e.g., application.yml or application.properties):
+ * </p>
+ *
+ * <ul>
+ *     <li><b>spring.jpa.properties.hibernate.detector.enabled:</b> Enable or disable the detector (default: false).</li>
+ *     <li><b>spring.jpa.properties.hibernate.detector.threshold:</b> Set the threshold for the number of query executions to detect an N+1 issue (default: 2).</li>
+ * </ul>
+ *
+ * <pre>
+ * Example configuration (YAML):
+ * jpa:
+ *   properties:
+ *     hibernate:
+ *       detector:
+ *         enabled: true
+ *         threshold: 2
+ * </pre>
+ *
+ * <pre>
+ * Example configuration (Properties):
+ * jpa.properties.hibernate.detector.enabled=true
+ * jpa.properties.hibernate.detector.threshold=3
+ * </pre>
+ *
+ * <p>
+ * The N+1 detector is disabled by default to avoid potential performance overhead in production environments.
+ * It is recommended to enable it only in development or testing environments.
+ * </p>
+ *
+ * @author jeyong
+ * @since 1.0
+ */
+// @formatter:on
 @ConfigurationProperties(prefix = "spring.jpa.properties.hibernate.detector")
 public class NPlusOneDetectorProperties {
 

--- a/detector/src/main/java/io/jeyong/detector/logging/NPlusOneQueryLogger.java
+++ b/detector/src/main/java/io/jeyong/detector/logging/NPlusOneQueryLogger.java
@@ -16,7 +16,7 @@ public final class NPlusOneQueryLogger {
     public void logNPlusOneIssues() {
         QueryContextHolder.getContext().getQueryCounts().forEach((query, count) -> {
             if (count >= queryThreshold) {
-                logger.warn("N+1 issue detected: Query '{}' was executed {} times.", query, count);
+                logger.warn("N+1 issue detected: '{}' was executed {} times.", query, count);
             }
         });
 

--- a/test/src/main/java/io/jeyong/test/InitData.java
+++ b/test/src/main/java/io/jeyong/test/InitData.java
@@ -16,9 +16,12 @@ import io.jeyong.test.case4.entity.Address;
 import io.jeyong.test.case4.entity.Person;
 import io.jeyong.test.case4.repository.AddressRepository;
 import io.jeyong.test.case4.repository.PersonRepository;
+import io.jeyong.test.case5.entity.Course;
+import io.jeyong.test.case5.entity.Student;
+import io.jeyong.test.case5.repository.CourseRepository;
+import io.jeyong.test.case5.repository.StudentRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -36,6 +39,8 @@ public class InitData {
     private final MemberRepository memberRepository;
     private final PersonRepository personRepository;
     private final AddressRepository addressRepository;
+    private final CourseRepository courseRepository;
+    private final StudentRepository studentRepository;
 
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
@@ -44,6 +49,7 @@ public class InitData {
         initCase2();
         initCase3();
         initCase4();
+        initCase5();
     }
 
     private void initCase1() {
@@ -171,5 +177,32 @@ public class InitData {
         person3.setAddress(address3);
 
         personRepository.saveAll(List.of(person1, person2, person3));
+    }
+
+    private void initCase5() {
+        Course course1 = new Course();
+        course1.setTitle("Course 1");
+
+        Course course2 = new Course();
+        course2.setTitle("Course 2");
+
+        Course course3 = new Course();
+        course3.setTitle("Course 3");
+
+        courseRepository.saveAll(List.of(course1, course2, course3));
+
+        Student student1 = new Student();
+        student1.setName("Student 1");
+        student1.getCourses().addAll(List.of(course1, course2));
+
+        Student student2 = new Student();
+        student2.setName("Student 2");
+        student2.getCourses().add(course2);
+
+        Student student3 = new Student();
+        student3.setName("Student 3");
+        student3.getCourses().addAll(List.of(course2, course3));
+
+        studentRepository.saveAll(List.of(student1, student2, student3));
     }
 }

--- a/test/src/main/java/io/jeyong/test/case1/controller/AuthorController.java
+++ b/test/src/main/java/io/jeyong/test/case1/controller/AuthorController.java
@@ -19,37 +19,37 @@ public class AuthorController {
     private final AuthorServiceV2 authorServiceV2;
     private final AuthorServiceV3 authorServiceV3;
 
+    // @formatter:off
     /**
-     * @formatter:off
      * Author과 Book는 일대다(1:N) 관계이며,
      * 모든 Author을 조회한 후 각 Author에 대해 별도의 쿼리로 Book을 조회
      * 클래스 단위의 @Transactional 상황에서 감지하는 것을 검증
-     * @formatter:on
      */
+    // @formatter:on
     @GetMapping("/v1/authors")
     public List<Author> getAuthorsV1() {
         return authorServiceV1.findAllAuthors();
     }
 
+    // @formatter:off
     /**
-     * @formatter:off
      * Author과 Book는 일대다(1:N) 관계이며,
      * 모든 Author을 조회한 후 각 Author에 대해 별도의 쿼리로 Book을 조회
      * 메서드 단위의 @Transactional 상황에서 감지하는 것을 검증
-     * @formatter:on
      */
+    // @formatter:on
     @GetMapping("/v2/authors")
     public List<Author> getAuthorsV2() {
         return authorServiceV2.findAllAuthors();
     }
 
+    // @formatter:off
     /**
-     * @formatter:off
      * Author과 Book는 일대다(1:N) 관계이며,
      * 모든 Author을 조회한 후 각 Author에 대해 별도의 쿼리로 Book을 조회
      * OSIV를 이용한 지연 조회 상황에서 감지하는 것을 검증
-     * @formatter:on
      */
+    // @formatter:on
     @GetMapping("/v3/authors")
     public List<Author> getAuthorsV3() {
         List<Author> allAuthors = authorServiceV3.findAllAuthors();

--- a/test/src/main/java/io/jeyong/test/case3/controller/TeamController.java
+++ b/test/src/main/java/io/jeyong/test/case3/controller/TeamController.java
@@ -15,13 +15,13 @@ public class TeamController {
 
     private final TeamService teamService;
 
+    // @formatter:off
     /**
-     * @formatter:off
      * Team과 Member는 일대다(1:N) 관계이며,
      * 모든 Team을 조회한 후 각 Team에 대해 별도의 쿼리로 Member를 조회
      * @BatchSize 상황에서 감지하지 않는 것을 검증
-     * @formatter:on
      */
+    // @formatter:on
     @GetMapping
     public List<Team> getAllTeams() {
         return teamService.findAllTeams();

--- a/test/src/main/java/io/jeyong/test/case4/controller/AddressController.java
+++ b/test/src/main/java/io/jeyong/test/case4/controller/AddressController.java
@@ -15,13 +15,13 @@ public class AddressController {
 
     private final AddressService addressService;
 
+    // @formatter:off
     /**
-     * @formatter:off
      * Address와 Person은 일대일(1:1) 관계
      * 모든 Address을 조회한 후 각 Address에 대해 즉시로딩으로 Person를 조회
      * 1:1 관계에서 연관관계의 주인이 아닌 일(1)을 조회하는 상황에서 감지하는 것을 검증
-     * @formatter:on
      */
+    // @formatter:on
     @GetMapping
     public List<Address> getAllAddresses() {
         return addressService.findAllAddresses();

--- a/test/src/main/java/io/jeyong/test/case4/controller/PersonController.java
+++ b/test/src/main/java/io/jeyong/test/case4/controller/PersonController.java
@@ -15,13 +15,13 @@ public class PersonController {
 
     private final PersonService personService;
 
+    // @formatter:off
     /**
-     * @formatter:off
      * Person과 Address는 일대일(1:1) 관계이며,
      * 모든 Person을 조회한 후 각 Person에 대해 별도의 쿼리로 Address를 조회
      * 1:1 관계에서 연관관계의 주인인 일(1)을 조회하는 상황에서 감지하는 것을 검증
-     * @formatter:on
      */
+    // @formatter:on
     @GetMapping
     public List<Person> getAllPersons() {
         return personService.findAllPersons();

--- a/test/src/main/java/io/jeyong/test/case5/controller/CourseController.http
+++ b/test/src/main/java/io/jeyong/test/case5/controller/CourseController.http
@@ -1,0 +1,2 @@
+### N:N 관계에서 연관관계의 주인이 아닌 다(N)를 조회하는 상황에서 감지하는 것을 검증
+GET http://localhost:8080/api/courses

--- a/test/src/main/java/io/jeyong/test/case5/controller/CourseController.java
+++ b/test/src/main/java/io/jeyong/test/case5/controller/CourseController.java
@@ -1,0 +1,29 @@
+package io.jeyong.test.case5.controller;
+
+import io.jeyong.test.case5.entity.Course;
+import io.jeyong.test.case5.service.CourseService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/courses")
+@RequiredArgsConstructor
+public class CourseController {
+
+    private final CourseService courseService;
+
+    // @formatter:off
+    /**
+     * Course와 Student는 다대다(N:N) 관계
+     * 모든 Course를 조회한 후 각 Course에 대해 별도의 쿼리로 Student를 조회
+     * N:N 관계에서 연관관계의 주인이 아닌 다(N)를 조회하는 상황에서 감지하는 것을 검증
+     */
+    // @formatter:on
+    @GetMapping
+    public List<Course> getAllCourses() {
+        return courseService.findAllCourses();
+    }
+}

--- a/test/src/main/java/io/jeyong/test/case5/controller/StudentController.http
+++ b/test/src/main/java/io/jeyong/test/case5/controller/StudentController.http
@@ -1,0 +1,2 @@
+### N:N 관계에서 연관관계의 주인인 다(N)를 조회하는 상황에서 감지하는 것을 검증
+GET http://localhost:8080/api/students

--- a/test/src/main/java/io/jeyong/test/case5/controller/StudentController.java
+++ b/test/src/main/java/io/jeyong/test/case5/controller/StudentController.java
@@ -1,0 +1,29 @@
+package io.jeyong.test.case5.controller;
+
+import io.jeyong.test.case5.entity.Student;
+import io.jeyong.test.case5.service.StudentService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/students")
+@RequiredArgsConstructor
+public class StudentController {
+
+    private final StudentService studentService;
+
+    // @formatter:off
+    /**
+     * Student와 Course는 다대다(N:N) 관계
+     * 모든 Student을 조회한 후 각 Student에 대해 별도의 쿼리로 Course를 조회
+     * N:N 관계에서 연관관계의 주인인 다(N)를 조회하는 상황에서 감지하는 것을 검증
+     */
+    // @formatter:on
+    @GetMapping
+    public List<Student> getAllStudents() {
+        return studentService.findAllStudents();
+    }
+}

--- a/test/src/main/java/io/jeyong/test/case5/entity/Course.java
+++ b/test/src/main/java/io/jeyong/test/case5/entity/Course.java
@@ -1,0 +1,31 @@
+package io.jeyong.test.case5.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Course {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @JsonIgnore
+    @ManyToMany(mappedBy = "courses", fetch = FetchType.LAZY)
+    private Set<Student> students = new HashSet<>();
+}

--- a/test/src/main/java/io/jeyong/test/case5/entity/Student.java
+++ b/test/src/main/java/io/jeyong/test/case5/entity/Student.java
@@ -1,0 +1,38 @@
+package io.jeyong.test.case5.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Student {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @JsonIgnore
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "student_course",
+            joinColumns = @JoinColumn(name = "student_id"),
+            inverseJoinColumns = @JoinColumn(name = "course_id")
+    )
+    private Set<Course> courses = new HashSet<>();
+}

--- a/test/src/main/java/io/jeyong/test/case5/repository/CourseRepository.java
+++ b/test/src/main/java/io/jeyong/test/case5/repository/CourseRepository.java
@@ -1,0 +1,7 @@
+package io.jeyong.test.case5.repository;
+
+import io.jeyong.test.case5.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+}

--- a/test/src/main/java/io/jeyong/test/case5/repository/StudentRepository.java
+++ b/test/src/main/java/io/jeyong/test/case5/repository/StudentRepository.java
@@ -1,0 +1,7 @@
+package io.jeyong.test.case5.repository;
+
+import io.jeyong.test.case5.entity.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudentRepository extends JpaRepository<Student, Long> {
+}

--- a/test/src/main/java/io/jeyong/test/case5/service/CourseService.java
+++ b/test/src/main/java/io/jeyong/test/case5/service/CourseService.java
@@ -1,0 +1,22 @@
+package io.jeyong.test.case5.service;
+
+import io.jeyong.test.case5.entity.Course;
+import io.jeyong.test.case5.repository.CourseRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+
+    @Transactional
+    public List<Course> findAllCourses() {
+        List<Course> courses = courseRepository.findAll();
+        courses.forEach(course -> course.getStudents().size());  // N+1 문제 발생
+        return courses;
+    }
+}

--- a/test/src/main/java/io/jeyong/test/case5/service/StudentService.java
+++ b/test/src/main/java/io/jeyong/test/case5/service/StudentService.java
@@ -1,0 +1,22 @@
+package io.jeyong.test.case5.service;
+
+import io.jeyong.test.case5.entity.Student;
+import io.jeyong.test.case5.repository.StudentRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StudentService {
+
+    private final StudentRepository studentRepository;
+
+    @Transactional
+    public List<Student> findAllStudents() {
+        List<Student> students = studentRepository.findAll();
+        students.forEach(student -> student.getCourses().size());  // N+1 문제 발생
+        return students;
+    }
+}

--- a/test/src/test/java/io/jeyong/test/case5/controller/CourseControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/case5/controller/CourseControllerTest.java
@@ -1,0 +1,37 @@
+package io.jeyong.test.case5.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class CourseControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("N:N 관계에서 연관관계의 주인이 아닌 다(N)를 조회하는 상황에서 감지한다.")
+    void testGetCourses(CapturedOutput output) {
+        String url = "http://localhost:" + port + "/api/courses";
+        ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(output).contains("N+1 issue detected");
+    }
+}

--- a/test/src/test/java/io/jeyong/test/case5/controller/StudentControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/case5/controller/StudentControllerTest.java
@@ -1,0 +1,37 @@
+package io.jeyong.test.case5.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class StudentControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("N:N 관계에서 연관관계의 주인인 다(N)를 조회하는 상황에서 감지한다.")
+    void testGetStudents(CapturedOutput output) {
+        String url = "http://localhost:" + port + "/api/students";
+        ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(output).contains("N+1 issue detected");
+    }
+}

--- a/test/src/test/java/io/jeyong/test/case5/service/CourseServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/case5/service/CourseServiceTest.java
@@ -1,0 +1,27 @@
+package io.jeyong.test.case5.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest
+public class CourseServiceTest {
+
+    @Autowired
+    private CourseService courseService;
+
+    @Test
+    @DisplayName("N:N 관계에서 연관관계의 주인이 아닌 다(N)를 조회하는 상황에서 감지한다.")
+    void testFindAllCourses(CapturedOutput output) {
+        courseService.findAllCourses();
+
+        assertThat(output).contains("N+1 issue detected");
+    }
+}

--- a/test/src/test/java/io/jeyong/test/case5/service/StudentServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/case5/service/StudentServiceTest.java
@@ -1,0 +1,27 @@
+package io.jeyong.test.case5.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest
+public class StudentServiceTest {
+
+    @Autowired
+    private StudentService studentService;
+
+    @Test
+    @DisplayName("N:N 관계에서 연관관계의 주인인 다(N)를 조회하는 상황에서 감지한다.")
+    void testFindAllStudents(CapturedOutput output) {
+        studentService.findAllStudents();
+
+        assertThat(output).contains("N+1 issue detected");
+    }
+}

--- a/test/src/test/java/io/jeyong/test/performance/LoggerPerformanceTest.java
+++ b/test/src/test/java/io/jeyong/test/performance/LoggerPerformanceTest.java
@@ -48,7 +48,7 @@ public class LoggerPerformanceTest {
         long startTime = System.nanoTime();
         queryContext.getQueryCounts().forEach((query, count) -> {
             if (count >= queryThreshold) {
-                logger.warn("N+1 issue detected: Query '{}' was executed {} times.", query, count);
+                logger.warn("N+1 issue detected: '{}' was executed {} times.", query, count);
             }
         });
         long endTime = System.nanoTime();
@@ -67,7 +67,7 @@ public class LoggerPerformanceTest {
             String query = entry.getKey();
             Long count = entry.getValue();
             if (count >= queryThreshold) {
-                logger.warn("N+1 issue detected: Query '{}' was executed {} times.", query, count);
+                logger.warn("N+1 issue detected: '{}' was executed {} times.", query, count);
             }
         });
         long endTime = System.nanoTime();
@@ -86,7 +86,7 @@ public class LoggerPerformanceTest {
             String query = entry.getKey();
             Long count = entry.getValue();
             if (count >= queryThreshold) {
-                logger.warn("N+1 issue detected: Query '{}' was executed {} times.", query, count);
+                logger.warn("N+1 issue detected: '{}' was executed {} times.", query, count);
             }
         });
         long endTime = System.nanoTime();


### PR DESCRIPTION
### 🔧 Refactoring
- **N+1 쿼리 감지 설정에 대한 javadoc 추가**
  - 감지기의 설정 파일에 대한 javadoc 문서를 추가하여, N+1 감지 기능을 사용하기 쉽게 설명했습니다. 

### 🔍 Test Enhancements
- **다대다(N:N) 관계에서 발생하는 N+1 문제에 대한 테스트 케이스 추가**
  - `/api/courses` 엔드포인트: `Course`와 `Student` 간의 다대다(N:N) 관계에서, 연관관계의 주인이 아닌 `Course`를 모두 조회한 후 각 `Course`에 연관된 `Student`를 별도의 쿼리로 조회할 때, 감지기가 N+1 문제를 감지하는지 검증합니다.
  - `/api/students` 엔드포인트: `Course`와 `Student` 간의 다대다(N:N) 관계에서, 연관관계의 주인인 `Student`를 모두 조회한 후 각 `Student`에 연관된 `Course`를 별도의 쿼리로 조회할 때, 감지기가 N+1 문제를 감지하는지 검증합니다.

### 🪲 Bug Fixes
- **로그 메시지 포맷 수정**
  - N+1 문제 감지 시 출력되는 로그 메시지에서 불필요한 구문을 제거하여 메시지가 더  간결하게 출력되도록 수정했습니다.
  
- **`@formatter:off`와 `@formatter:on`의 위치 문제 수정**
  - 기존 테스트 코드에서 `@formatter:off`와 `@formatter:on`의 위치 문제로 인해 테스트 코드의 설명이 제대로 출력되지 않는 문제를 수정하였습니다.
