### PR TITLE
Release v1.4.0 

### DIFF
--- a/detector/build.gradle
+++ b/detector/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.jeyong'
-version = '1.3.2'
+version = '1.4.0'
 
 java {
     toolchain {

--- a/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorConfig.java
+++ b/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorConfig.java
@@ -38,7 +38,8 @@ public class NPlusOneDetectorConfig {
 
     @Bean
     public NPlusOneQueryLogger nPlusOneQueryLogger() {
-        return new NPlusOneQueryLogger(nPlusOneDetectorProperties.getThreshold());
+        return new NPlusOneQueryLogger(nPlusOneDetectorProperties.getThreshold(),
+                nPlusOneDetectorProperties.getLevel());
     }
 
     @Bean

--- a/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorProperties.java
+++ b/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorProperties.java
@@ -1,5 +1,6 @@
 package io.jeyong.detector.config;
 
+import org.slf4j.event.Level;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 // @formatter:off
@@ -17,6 +18,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * <ul>
  *     <li><b>spring.jpa.properties.hibernate.detector.enabled:</b> Enable or disable the detector (default: false).</li>
  *     <li><b>spring.jpa.properties.hibernate.detector.threshold:</b> Set the threshold for the number of query executions to detect an N+1 issue (default: 2).</li>
+ *     <li><b>spring.jpa.properties.hibernate.detector.level:</b> Set the log level for detected N+1 issues (default: WARN).</li>
  * </ul>
  *
  * <pre>
@@ -27,12 +29,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *       detector:
  *         enabled: true
  *         threshold: 2
+ *         level: WARN
  * </pre>
  *
  * <pre>
  * Example configuration (Properties):
  * jpa.properties.hibernate.detector.enabled=true
- * jpa.properties.hibernate.detector.threshold=3
+ * jpa.properties.hibernate.detector.threshold=2
+ * jpa.properties.hibernate.detector.level=WARN
  * </pre>
  *
  * <p>
@@ -51,6 +55,8 @@ public class NPlusOneDetectorProperties {
 
     private int threshold = 2;
 
+    private Level level = Level.WARN;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -65,5 +71,13 @@ public class NPlusOneDetectorProperties {
 
     public void setThreshold(final int threshold) {
         this.threshold = threshold;
+    }
+
+    public Level getLevel() {
+        return level;
+    }
+
+    public void setLevel(final Level level) {
+        this.level = level;
     }
 }

--- a/detector/src/main/java/io/jeyong/detector/logging/NPlusOneQueryLogger.java
+++ b/detector/src/main/java/io/jeyong/detector/logging/NPlusOneQueryLogger.java
@@ -17,12 +17,15 @@ public final class NPlusOneQueryLogger {
     }
 
     public void logNPlusOneIssues() {
-        QueryContextHolder.getContext().getQueryCounts().forEach((query, count) -> {
-            if (count >= queryThreshold) {
-                logBasedOnLevel(query, count);
-            }
-        });
-        QueryContextHolder.clearContext();
+        try {
+            QueryContextHolder.getContext().getQueryCounts().forEach((query, count) -> {
+                if (count >= queryThreshold) {
+                    logBasedOnLevel(query, count);
+                }
+            });
+        } finally {
+            QueryContextHolder.clearContext();
+        }
     }
 
     private void logBasedOnLevel(String query, long count) {

--- a/detector/src/main/java/io/jeyong/detector/logging/NPlusOneQueryLogger.java
+++ b/detector/src/main/java/io/jeyong/detector/logging/NPlusOneQueryLogger.java
@@ -3,23 +3,39 @@ package io.jeyong.detector.logging;
 import io.jeyong.detector.context.QueryContextHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 public final class NPlusOneQueryLogger {
 
     private static final Logger logger = LoggerFactory.getLogger(NPlusOneQueryLogger.class);
     private final int queryThreshold;
+    private final Level level;
 
-    public NPlusOneQueryLogger(final int queryThreshold) {
+    public NPlusOneQueryLogger(final int queryThreshold, final Level level) {
         this.queryThreshold = queryThreshold;
+        this.level = level;
     }
 
     public void logNPlusOneIssues() {
         QueryContextHolder.getContext().getQueryCounts().forEach((query, count) -> {
             if (count >= queryThreshold) {
-                logger.warn("N+1 issue detected: '{}' was executed {} times.", query, count);
+                logBasedOnLevel(query, count);
             }
         });
-
         QueryContextHolder.clearContext();
+    }
+
+    private void logBasedOnLevel(String query, long count) {
+        if (level == Level.WARN && logger.isWarnEnabled()) {
+            logger.warn("N+1 issue detected: '{}' was executed {} times.", query, count);
+        } else if (level == Level.TRACE && logger.isTraceEnabled()) {
+            logger.trace("N+1 issue detected: '{}' was executed {} times.", query, count);
+        } else if (level == Level.INFO && logger.isInfoEnabled()) {
+            logger.info("N+1 issue detected: '{}' was executed {} times.", query, count);
+        } else if (level == Level.DEBUG && logger.isDebugEnabled()) {
+            logger.debug("N+1 issue detected: '{}' was executed {} times.", query, count);
+        } else if (level == Level.ERROR && logger.isErrorEnabled()) {
+            logger.error("N+1 issue detected: '{}' was executed {} times.", query, count);
+        }
     }
 }

--- a/test/src/main/resources/application.yml
+++ b/test/src/main/resources/application.yml
@@ -19,6 +19,6 @@ spring:
         detector:
           enabled: true     # N+1 문제 감지 기능 활성화 여부 / 기본 값 : false
           threshold: 2      # 쿼리 실행 횟수 기준 설정 (예: 3회 이상 실행된 쿼리에 대해 N+1 문제 감지) / 기본 값 : 2
-
+          level: warn      # 감지된 N+1 문제에 대한 로깅 레벨 설정 (error, warn, info, debug) / 기본 값 : warn
     #    open-in-view: false
     show-sql: true

--- a/test/src/test/java/io/jeyong/test/level/LoggerLevelDebugTest.java
+++ b/test/src/test/java/io/jeyong/test/level/LoggerLevelDebugTest.java
@@ -1,0 +1,42 @@
+package io.jeyong.test.level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "logging.level.io.jeyong=debug",
+                "spring.jpa.properties.hibernate.detector.level=debug"
+        })
+class LoggerLevelDebugTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("DEBUG 레벨에서 로그가 출력된다.")
+    void testDebugLogLevel(CapturedOutput output) {
+        String url = "http://localhost:" + port + "/api/products";
+        ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(output).contains("N+1 issue detected");
+    }
+}

--- a/test/src/test/java/io/jeyong/test/level/LoggerLevelErrorTest.java
+++ b/test/src/test/java/io/jeyong/test/level/LoggerLevelErrorTest.java
@@ -1,0 +1,42 @@
+package io.jeyong.test.level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "logging.level.io.jeyong=error",
+                "spring.jpa.properties.hibernate.detector.level=error"
+        })
+class LoggerLevelErrorTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("ERROR 레벨에서 로그가 출력된다.")
+    void testErrorLogLevel(CapturedOutput output) {
+        String url = "http://localhost:" + port + "/api/products";
+        ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(output).contains("N+1 issue detected");
+    }
+}

--- a/test/src/test/java/io/jeyong/test/level/LoggerLevelInfoTest.java
+++ b/test/src/test/java/io/jeyong/test/level/LoggerLevelInfoTest.java
@@ -1,0 +1,42 @@
+package io.jeyong.test.level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "logging.level.io.jeyong=info",
+                "spring.jpa.properties.hibernate.detector.level=info"
+        })
+class LoggerLevelInfoTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("INFO 레벨에서 로그가 출력된다.")
+    void testInfoLogLevel(CapturedOutput output) {
+        String url = "http://localhost:" + port + "/api/products";
+        ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(output).contains("N+1 issue detected");
+    }
+}

--- a/test/src/test/java/io/jeyong/test/level/LoggerLevelTraceTest.java
+++ b/test/src/test/java/io/jeyong/test/level/LoggerLevelTraceTest.java
@@ -1,0 +1,42 @@
+package io.jeyong.test.level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "logging.level.io.jeyong=trace",
+                "spring.jpa.properties.hibernate.detector.level=trace"
+        })
+class LoggerLevelTraceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("TRACE 레벨에서 로그가 출력된다.")
+    void testTraceLogLevel(CapturedOutput output) {
+        String url = "http://localhost:" + port + "/api/products";
+        ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(output).contains("N+1 issue detected");
+    }
+}

--- a/test/src/test/java/io/jeyong/test/level/LoggerLevelWarnTest.java
+++ b/test/src/test/java/io/jeyong/test/level/LoggerLevelWarnTest.java
@@ -1,0 +1,42 @@
+package io.jeyong.test.level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "logging.level.io.jeyong=warn",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
+class LoggerLevelWarnTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("WARN 레벨에서 로그가 출력된다.")
+    void testWarnLogLevel(CapturedOutput output) {
+        String url = "http://localhost:" + port + "/api/products";
+        ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(output).contains("N+1 issue detected");
+    }
+}


### PR DESCRIPTION
### ⭐ New Features
- **로그 레벨 설정 기능 추가**
  - N+1 문제 감지 시 로그 레벨을 설정할 수 있는 기능이 추가되었습니다. 이제 사용자는 `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE` 중 하나의 레벨을 선택하여, 원하는 로그 레벨에 맞춰 N+1 감지 로그를 출력할 수 있습니다.
  ```yaml
  jpa:
    properties:
      hibernate:
        detector:
          level: warn      # 감지된 N+1 문제에 대한 로깅 레벨 설정 (error, warn, info, debug, trace) / 기본 값 : warn
  ```

### 🔍 Test Enhancements
- **로그 레벨별 테스트 클래스 추가**
  - 각 테스트 클래스에서 다른 로그 레벨 환경을 설정하여, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE` 레벨별로 N+1 문제 감지 로그가 올바르게 출력되는지 검증하는 테스트를 추가했습니다. 
  - 각각의 테스트 클래스는 해당 로그 레벨에 맞게 환경을 설정하여 N+1 로그가 적절히 출력되는지를 확인합니다.

### 🪲 Bug Fixes
- **finally 블록을 이용한 ThreadLocal 제거 방식 개선**
  - `ThreadLocal`이 제대로 해제되지 않는 상황을 방지하기 위해, `finally` 블록을 사용하여 항상 `ThreadLocal`을 올바르게 해제하도록 로직을 수정했습니다.

