### PR TITLE
Release v2.3.0

### DIFF
--- a/detector/build.gradle
+++ b/detector/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.jeyong'
-version = '2.2.0'
+version = '2.3.0'
 
 java {
     toolchain {

--- a/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorBaseConfig.java
+++ b/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorBaseConfig.java
@@ -26,5 +26,5 @@ public abstract class NPlusOneDetectorBaseConfig {
         return hibernateProperties -> hibernateProperties.put(STATEMENT_INSPECTOR, queryCaptureInspector);
     }
 
-    protected abstract NPlusOneQueryTemplate nPlusOneQueryTemplate();
+    public abstract NPlusOneQueryTemplate nPlusOneQueryTemplate();
 }

--- a/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorProperties.java
+++ b/detector/src/main/java/io/jeyong/detector/config/NPlusOneDetectorProperties.java
@@ -70,7 +70,7 @@ public class NPlusOneDetectorProperties {
 
     private int threshold = 2;
 
-    private List<String> exclude;
+    private List<String> exclude = List.of();
 
     private Level level = Level.WARN;
 

--- a/detector/src/main/java/io/jeyong/detector/context/ExceptionContext.java
+++ b/detector/src/main/java/io/jeyong/detector/context/ExceptionContext.java
@@ -13,9 +13,9 @@ public final class ExceptionContext {
             if (existingException != null) {
                 existingException.addSuppressed(nPlusOneQueryException);
                 return existingException;
-            } else {
-                return nPlusOneQueryException;
             }
+
+            return nPlusOneQueryException;
         });
     }
 

--- a/test/src/test/java/io/jeyong/test/environment/main/case1/controller/AuthorControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case1/controller/AuthorControllerTest.java
@@ -16,7 +16,14 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 class AuthorControllerTest {
 
     @LocalServerPort

--- a/test/src/test/java/io/jeyong/test/environment/main/case1/service/AuthorServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case1/service/AuthorServiceTest.java
@@ -14,7 +14,13 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest
+@SpringBootTest(
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 public class AuthorServiceTest {
 
     @Autowired

--- a/test/src/test/java/io/jeyong/test/environment/main/case2/controller/ProductControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case2/controller/ProductControllerTest.java
@@ -16,7 +16,14 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 class ProductControllerTest {
 
     @LocalServerPort

--- a/test/src/test/java/io/jeyong/test/environment/main/case2/service/ProductServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case2/service/ProductServiceTest.java
@@ -12,7 +12,13 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest
+@SpringBootTest(
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 public class ProductServiceTest {
 
     @Autowired

--- a/test/src/test/java/io/jeyong/test/environment/main/case3/controller/TeamControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case3/controller/TeamControllerTest.java
@@ -16,7 +16,14 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 class TeamControllerTest {
 
     @LocalServerPort

--- a/test/src/test/java/io/jeyong/test/environment/main/case3/service/TeamServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case3/service/TeamServiceTest.java
@@ -12,7 +12,13 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest
+@SpringBootTest(
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 public class TeamServiceTest {
 
     @Autowired

--- a/test/src/test/java/io/jeyong/test/environment/main/case4/controller/AddressControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case4/controller/AddressControllerTest.java
@@ -16,7 +16,14 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 class AddressControllerTest {
 
     @LocalServerPort

--- a/test/src/test/java/io/jeyong/test/environment/main/case4/controller/PersonControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case4/controller/PersonControllerTest.java
@@ -16,7 +16,14 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 class PersonControllerTest {
 
     @LocalServerPort

--- a/test/src/test/java/io/jeyong/test/environment/main/case4/service/AddressServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case4/service/AddressServiceTest.java
@@ -12,7 +12,13 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest
+@SpringBootTest(
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 public class AddressServiceTest {
 
     @Autowired

--- a/test/src/test/java/io/jeyong/test/environment/main/case4/service/PersonServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case4/service/PersonServiceTest.java
@@ -12,7 +12,13 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest
+@SpringBootTest(
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 public class PersonServiceTest {
 
     @Autowired

--- a/test/src/test/java/io/jeyong/test/environment/main/case5/controller/CourseControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case5/controller/CourseControllerTest.java
@@ -16,7 +16,14 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 class CourseControllerTest {
 
     @LocalServerPort

--- a/test/src/test/java/io/jeyong/test/environment/main/case5/controller/StudentControllerTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case5/controller/StudentControllerTest.java
@@ -16,7 +16,14 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT)
+@SpringBootTest(
+        webEnvironment = RANDOM_PORT,
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 class StudentControllerTest {
 
     @LocalServerPort

--- a/test/src/test/java/io/jeyong/test/environment/main/case5/service/CourseServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case5/service/CourseServiceTest.java
@@ -12,7 +12,13 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest
+@SpringBootTest(
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 public class CourseServiceTest {
 
     @Autowired

--- a/test/src/test/java/io/jeyong/test/environment/main/case5/service/StudentServiceTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/case5/service/StudentServiceTest.java
@@ -12,7 +12,13 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest
+@SpringBootTest(
+        properties = {
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn"
+        })
 public class StudentServiceTest {
 
     @Autowired

--- a/test/src/test/java/io/jeyong/test/environment/main/exclude/ExcludeQueryTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/exclude/ExcludeQueryTest.java
@@ -23,7 +23,7 @@ import org.springframework.http.ResponseEntity;
                 "spring.jpa.properties.hibernate.detector.threshold=2",
                 "spring.jpa.properties.hibernate.detector.exclude[0]=select b1_0.author_id,b1_0.id,b1_0.title from book b1_0 where b1_0.author_id=?",
                 "spring.jpa.properties.hibernate.detector.exclude[1]=select o1_0.id,o1_0.order_number from \"order\" o1_0 where o1_0.id=?",
-                "spring.jpa.properties.hibernate.detector.level=info",
+                "spring.jpa.properties.hibernate.detector.level=warn",
         })
 class ExcludeQueryTest {
 

--- a/test/src/test/java/io/jeyong/test/environment/main/level/LoggerLevelDebugTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/level/LoggerLevelDebugTest.java
@@ -19,8 +19,11 @@ import org.springframework.http.ResponseEntity;
 @SpringBootTest(
         webEnvironment = RANDOM_PORT,
         properties = {
-                "logging.level.io.jeyong=debug",
-                "spring.jpa.properties.hibernate.detector.level=debug"
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=debug",
+                "logging.level.io.jeyong=debug"
         })
 class LoggerLevelDebugTest {
 

--- a/test/src/test/java/io/jeyong/test/environment/main/level/LoggerLevelErrorTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/level/LoggerLevelErrorTest.java
@@ -19,8 +19,11 @@ import org.springframework.http.ResponseEntity;
 @SpringBootTest(
         webEnvironment = RANDOM_PORT,
         properties = {
-                "logging.level.io.jeyong=error",
-                "spring.jpa.properties.hibernate.detector.level=error"
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=error",
+                "logging.level.io.jeyong=error"
         })
 class LoggerLevelErrorTest {
 

--- a/test/src/test/java/io/jeyong/test/environment/main/level/LoggerLevelInfoTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/level/LoggerLevelInfoTest.java
@@ -19,8 +19,11 @@ import org.springframework.http.ResponseEntity;
 @SpringBootTest(
         webEnvironment = RANDOM_PORT,
         properties = {
-                "logging.level.io.jeyong=info",
-                "spring.jpa.properties.hibernate.detector.level=info"
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=info",
+                "logging.level.io.jeyong=info"
         })
 class LoggerLevelInfoTest {
 

--- a/test/src/test/java/io/jeyong/test/environment/main/level/LoggerLevelTraceTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/level/LoggerLevelTraceTest.java
@@ -19,8 +19,11 @@ import org.springframework.http.ResponseEntity;
 @SpringBootTest(
         webEnvironment = RANDOM_PORT,
         properties = {
-                "logging.level.io.jeyong=trace",
-                "spring.jpa.properties.hibernate.detector.level=trace"
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=trace",
+                "logging.level.io.jeyong=trace"
         })
 class LoggerLevelTraceTest {
 

--- a/test/src/test/java/io/jeyong/test/environment/main/level/LoggerLevelWarnTest.java
+++ b/test/src/test/java/io/jeyong/test/environment/main/level/LoggerLevelWarnTest.java
@@ -19,8 +19,11 @@ import org.springframework.http.ResponseEntity;
 @SpringBootTest(
         webEnvironment = RANDOM_PORT,
         properties = {
-                "logging.level.io.jeyong=warn",
-                "spring.jpa.properties.hibernate.detector.level=warn"
+                "spring.jpa.properties.hibernate.detector.enabled=true",
+                "spring.jpa.properties.hibernate.detector.threshold=2",
+                "spring.jpa.properties.hibernate.detector.exclude=",
+                "spring.jpa.properties.hibernate.detector.level=warn",
+                "logging.level.io.jeyong=warn"
         })
 class LoggerLevelWarnTest {
 


### PR DESCRIPTION
### 🪲 Bug Fixes
- **exclude 설정 미지정 시 NullPointerException 발생 문제 해결**  
  - `NPlusOneDetectorProperties`의 `exclude` 필드가 설정 파일에 명시되지 않았을 때 `null` 상태로 남아 `NullPointerException`이 발생할 수 있는 문제를 수정하였습니다.  
  - 해당 필드에 기본값으로 `List.of()`를 할당하여 항상 빈 리스트를 반환하도록 개선하였습니다.

- **메인 환경 테스트에서 누락된 detector 설정 명시**  
  - 모든 테스트 클래스에 `enabled`, `threshold`, `exclude`, `level` 프로퍼티를 명시적으로 선언하여 테스트 환경 일관성을 확보하였습니다.
